### PR TITLE
Use correct API endpoint in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 SITE_URL = "http://localhost:3000"
-NEXT_PUBLIC_API_ENDPOINT = "http://localhost:4000/api/"
+NEXT_PUBLIC_API_ENDPOINT = "http://localhost:3000/api/v1/"
 NEXT_PUBLIC_NEXT_APP_ENV = "development"
 NEXT_PUBLIC_BUGSNAG_API_KEY = "YOUR_BUGSNAG_API_KEY"


### PR DESCRIPTION
## Summary

## Description

Update changes to .env.example, specifically the `NEXT_PUBLIC_API_ENDPOINT` and append `/v1/`.
This makes the proxy work out of the box.

## Checklist:

- [x] Code is linted and prettified before the review
- [x] I have performed a self-review of my code
- [x] Tests pass locally with my changes
