### PR TITLE
fix: update onboarding api slug

### DIFF
--- a/src/pages/api/[[...slug]].ts
+++ b/src/pages/api/[[...slug]].ts
@@ -2,7 +2,7 @@ import { IncomingMessage } from 'http';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { NextApiRequest, NextApiResponse } from 'next';
 
-const apiUrl = 'http://localhost:8080';
+const apiUrl = 'http://127.0.0.1:8080';
 
 const proxy = createProxyMiddleware({
 	target: apiUrl,


### PR DESCRIPTION
Pointing to localhost with http-proxy-middleware can cause a ECONNREFUSED error in Node v17+, so 127.0.0.1 should be used instead.

It has to do with the DNS lookup for IPv4 versus IPv6 in Node, see this issue: https://github.com/chimurai/http-proxy-middleware/issues/705