### PR TITLE
Update tailwind Intellisense setting to use classFunction

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,11 +11,7 @@
 	},
 	// Enables Tailwind CSS IntelliSense extension in "cva" and "cn" functions,
 	// sorting is configured in Prettier settings
-	"tailwindCSS.experimental.classRegex": [
-		["cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
-		["cn\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-	],
-
+	"tailwindCSS.classFunctions": ["cva", "cn"],
 	/**
 	 * VSCode formatting and static code analysis settings
 	 */


### PR DESCRIPTION
CVA doc suggest this simpler approach to supporting intellisense within cva and cn functions.

See https://cva.style/docs/getting-started/installation
